### PR TITLE
fix: ensure crypto.getRandomValues is available for docs dev server

### DIFF
--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,7 +1,54 @@
+import { randomFillSync, webcrypto as nodeWebCrypto } from "node:crypto";
 import { fileURLToPath, URL } from "node:url";
 
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+
+type CryptoWithGetRandomValues = Partial<Crypto> & Pick<Crypto, "getRandomValues">;
+
+const defineGlobalCrypto = (value: CryptoWithGetRandomValues): void => {
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value,
+  });
+};
+
+const ensureCryptoGetRandomValues = (): void => {
+  const existingCrypto = globalThis.crypto as Crypto | undefined;
+
+  if (typeof existingCrypto?.getRandomValues === "function") {
+    return;
+  }
+
+  const webCryptoCandidate = nodeWebCrypto as Crypto | undefined;
+
+  if (typeof webCryptoCandidate?.getRandomValues === "function") {
+    defineGlobalCrypto(webCryptoCandidate);
+    return;
+  }
+
+  const getRandomValues = <T extends ArrayBufferView>(array: T): T => {
+    randomFillSync(array);
+    return array;
+  };
+
+  if (existingCrypto) {
+    Object.defineProperty(existingCrypto, "getRandomValues", {
+      configurable: true,
+      value: getRandomValues,
+      writable: true,
+    });
+    return;
+  }
+
+  const polyfilledCrypto: CryptoWithGetRandomValues = {
+    getRandomValues,
+  };
+
+  defineGlobalCrypto(polyfilledCrypto);
+};
+
+ensureCryptoGetRandomValues();
 
 const repositoryName = process.env.GITHUB_REPOSITORY?.split("/")[1];
 const defaultBase = repositoryName ? `/${repositoryName}/` : "/";


### PR DESCRIPTION
## Summary
- polyfill `crypto.getRandomValues` in the Vite config so the docs dev server works when Bun lacks Web Crypto
- fall back to Node's `webcrypto` implementation or `randomFillSync` to guarantee a compliant API

## Testing
- bun run docs:build
- bun run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68d12548c1f4832ebe407d21dbf9363b