### PR TITLE
fix docs deploy workflow artifact action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build documentation
         run: DOCS_BASE=/${{ github.event.repository.name }}/ bun run docs:build
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs/dist
   deploy:


### PR DESCRIPTION
## Summary
- upgrade the GitHub Pages artifact upload step to the latest action version to avoid the deprecated upload-artifact v3 dependency

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d128e4d578832ea92e343141ef5b9e