### PR TITLE
docs: showcase all primitives with new demos

### DIFF
--- a/docs/src/components/demos/AppShellDemo.tsx
+++ b/docs/src/components/demos/AppShellDemo.tsx
@@ -1,0 +1,248 @@
+import { useMemo } from "react";
+
+import {
+  Avatar,
+  Badge,
+  Box,
+  Button,
+  Card,
+  Stack,
+  Text,
+  useApolloTheme,
+} from "@apollo/ui";
+
+interface NavigationItem {
+  readonly id: string;
+  readonly label: string;
+  readonly helper: string;
+  readonly active?: boolean;
+  readonly badge?: string;
+}
+
+const NAVIGATION_ITEMS: ReadonlyArray<NavigationItem> = [
+  { id: "overview", label: "Overview", helper: "System health", active: true },
+  { id: "components", label: "Components", helper: "24 primitives", badge: "24" },
+  { id: "tokens", label: "Tokens", helper: "Color & type" },
+  { id: "patterns", label: "Patterns", helper: "Usage guidance" },
+  { id: "changelog", label: "Changelog", helper: "Latest releases" },
+];
+
+const QUICK_LINKS = [
+  { id: "accessibility", label: "Accessibility audit" },
+  { id: "roadmap", label: "Roadmap review" },
+  { id: "support", label: "Support requests" },
+] as const;
+
+const COLLABORATORS = [
+  { id: "aria", name: "Aria Chen", status: "online" as const },
+  { id: "diego", name: "Diego Patel", status: "busy" as const },
+  { id: "morgan", name: "Morgan Lee", status: "offline" as const },
+];
+
+export function AppShellDemo(): JSX.Element {
+  const { theme } = useApolloTheme();
+
+  const collaboratorInitials = useMemo(
+    () =>
+      COLLABORATORS.map((person) => ({
+        id: person.id,
+        name: person.name,
+        status: person.status,
+        initials: person.name
+          .split(/\s+/u)
+          .map((part) => part[0])
+          .join("")
+          .toUpperCase(),
+      })),
+    [],
+  );
+
+  return (
+    <Box
+      display="grid"
+      radius="xl"
+      shadow="sm"
+      border="subtle"
+      background="surface"
+      style={{
+        gridTemplateColumns: "220px 1fr",
+        minHeight: "320px",
+        overflow: "hidden",
+      }}
+    >
+      <Box
+        as="aside"
+        padding="5"
+        background="surfaceSunken"
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: theme.space["6"],
+          borderRight: `1px solid ${theme.colors.border.subtle}`,
+        }}
+        aria-label="Primary navigation"
+      >
+        <Stack gap="3">
+          <Stack gap="1">
+            <Text as="span" variant="subtitle" weight="semibold">
+              Apollo UI
+            </Text>
+            <Badge variant="subtle" tone="accent">
+              v0.3 preview
+            </Badge>
+          </Stack>
+          <Text as="p" variant="detail" color="secondary">
+            Navigate tokens, primitives, and adoption resources.
+          </Text>
+        </Stack>
+        <Stack gap="1" style={{ flex: "1 1 auto" }}>
+          {NAVIGATION_ITEMS.map((item) => (
+            <Button
+              key={item.id}
+              size="sm"
+              fullWidth
+              variant={item.active ? "solid" : "ghost"}
+              tone={item.active ? "accent" : "neutral"}
+              aria-current={item.active ? "page" : undefined}
+            >
+              <Box
+                display="flex"
+                justify="space-between"
+                align="center"
+                style={{ width: "100%" }}
+              >
+                <Stack gap="1">
+                  <Text as="span" variant="bodySm" weight="semibold">
+                    {item.label}
+                  </Text>
+                  <Text as="span" variant="detail" color="muted">
+                    {item.helper}
+                  </Text>
+                </Stack>
+                {item.badge ? (
+                  <Badge variant="subtle" tone="accent">
+                    {item.badge}
+                  </Badge>
+                ) : null}
+              </Box>
+            </Button>
+          ))}
+        </Stack>
+        <Stack gap="3">
+          <Text as="span" variant="detail" color="secondary" weight="semibold">
+            Quick links
+          </Text>
+          <Stack gap="2">
+            {QUICK_LINKS.map((link) => (
+              <Button key={link.id} size="sm" variant="ghost" tone="neutral" fullWidth>
+                {link.label}
+              </Button>
+            ))}
+          </Stack>
+        </Stack>
+        <Card padding="4" radius="lg" shadow="xs" background="surfaceRaised">
+          <Stack gap="3">
+            <Stack gap="1">
+              <Text as="span" variant="detail" color="secondary" weight="semibold">
+                Collaborators
+              </Text>
+              <Text as="p" variant="bodySm">
+                Invite partners to ship updates with shared guidelines.
+              </Text>
+            </Stack>
+            <Stack direction="horizontal" gap="2">
+              {collaboratorInitials.map((person) => (
+                <Avatar
+                  key={person.id}
+                  name={person.name}
+                  size="sm"
+                  status={person.status}
+                  aria-label={`${person.name} status ${person.status}`}
+                >
+                  {person.initials}
+                </Avatar>
+              ))}
+            </Stack>
+            <Button size="sm" tone="accent" variant="subtle" fullWidth>
+              Invite teammate
+            </Button>
+          </Stack>
+        </Card>
+      </Box>
+      <Box display="flex" direction="column">
+        <Box
+          as="header"
+          paddingX="5"
+          paddingY="4"
+          style={{
+            borderBottom: `1px solid ${theme.colors.border.subtle}`,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: theme.space["4"],
+          }}
+        >
+          <Stack gap="1">
+            <Text as="h4" variant="headline" weight="semibold">
+              Design system overview
+            </Text>
+            <Text as="p" variant="detail" color="secondary">
+              Track adoption, readiness, and guidance from a unified workspace.
+            </Text>
+          </Stack>
+          <Stack direction="horizontal" gap="3" align="center">
+            <Badge variant="subtle" tone="success">
+              Stable
+            </Badge>
+            <Button size="sm" variant="outline" tone="neutral">
+              Share feedback
+            </Button>
+            <Avatar name="Jordan Blake" size="sm" status="online" />
+          </Stack>
+        </Box>
+        <Box as="section" padding="5" style={{ flex: "1 1 auto" }}>
+          <Stack gap="4">
+            <Card padding="5" radius="lg" shadow="xs" background="surfaceRaised">
+              <Stack gap="2">
+                <Text as="h5" variant="subtitle" weight="semibold">
+                  This week’s highlights
+                </Text>
+                <Text as="p" variant="body" color="secondary">
+                  Three new component drafts are ready for review and accessibility coverage increased by 12%.
+                </Text>
+              </Stack>
+            </Card>
+            <Stack direction="horizontal" gap="4" wrap>
+              <Card padding="4" radius="lg" shadow="xs" background="surfaceSunken" style={{ flex: "1 1 180px" }}>
+                <Stack gap="2">
+                  <Text as="span" variant="detail" color="secondary">
+                    Adoption
+                  </Text>
+                  <Text as="span" variant="subtitle" weight="semibold">
+                    68%
+                  </Text>
+                  <Text as="span" variant="detail" color="muted">
+                    Teams migrated to Apollo UI
+                  </Text>
+                </Stack>
+              </Card>
+              <Card padding="4" radius="lg" shadow="xs" background="surfaceSunken" style={{ flex: "1 1 180px" }}>
+                <Stack gap="2">
+                  <Text as="span" variant="detail" color="secondary">
+                    Open feedback
+                  </Text>
+                  <Text as="span" variant="subtitle" weight="semibold">
+                    14
+                  </Text>
+                  <Text as="span" variant="detail" color="muted">
+                    Awaiting triage
+                  </Text>
+                </Stack>
+              </Card>
+            </Stack>
+          </Stack>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/src/components/demos/DashboardDemo.tsx
+++ b/docs/src/components/demos/DashboardDemo.tsx
@@ -1,0 +1,135 @@
+import { useMemo } from "react";
+
+import {
+  Badge,
+  Box,
+  Button,
+  Card,
+  DataTable,
+  DatePicker,
+  Progress,
+  Stack,
+  Text,
+  type DataTableColumn,
+} from "@apollo/ui";
+
+interface WorkstreamRow {
+  readonly id: number;
+  readonly name: string;
+  readonly status: "Ready" | "In review" | "Draft";
+  readonly owner: string;
+  readonly updated: string;
+}
+
+const STATUS_TONE: Record<WorkstreamRow["status"], "success" | "warning" | "neutral"> = {
+  Ready: "success",
+  "In review": "warning",
+  Draft: "neutral",
+};
+
+const WORKSTREAM_ROWS: ReadonlyArray<WorkstreamRow> = [
+  { id: 1, name: "Navigation shell", status: "Ready", owner: "Alex Morgan", updated: "2 days ago" },
+  { id: 2, name: "Command palette", status: "In review", owner: "Priya Das", updated: "5 days ago" },
+  { id: 3, name: "Context menu", status: "Draft", owner: "Liam Patel", updated: "1 day ago" },
+];
+
+export function DashboardDemo(): JSX.Element {
+  const columns = useMemo<ReadonlyArray<DataTableColumn<WorkstreamRow>>>(() => [
+    {
+      id: "component",
+      header: "Component",
+      accessor: (row) => row.name,
+      sortable: true,
+    },
+    {
+      id: "status",
+      header: "Status",
+      accessor: (row) => row.status,
+      cell: (row) => (
+        <Badge variant="subtle" tone={STATUS_TONE[row.status]}>
+          {row.status}
+        </Badge>
+      ),
+    },
+    {
+      id: "owner",
+      header: "Owner",
+      accessor: (row) => row.owner,
+    },
+    {
+      id: "updated",
+      header: "Updated",
+      accessor: (row) => row.updated,
+      sortable: true,
+      align: "right",
+    },
+  ], []);
+
+  return (
+    <Stack gap="5">
+      <Stack direction="horizontal" align="center" justify="space-between" wrap gap="4">
+        <Stack gap="1">
+          <Text as="h4" variant="subtitle" weight="semibold">
+            Release readiness dashboard
+          </Text>
+          <Text as="p" variant="detail" color="secondary">
+            Monitor component health, adoption velocity, and review progress.
+          </Text>
+        </Stack>
+        <Stack direction="horizontal" gap="3" align="center" wrap>
+          <DatePicker placeholder="Filter by milestone" />
+          <Button size="sm" variant="outline" tone="neutral">
+            Export report
+          </Button>
+        </Stack>
+      </Stack>
+      <Stack direction="horizontal" gap="4" wrap>
+        <Card padding="4" radius="lg" shadow="xs" background="surfaceRaised" style={{ flex: "1 1 180px" }}>
+          <Stack gap="2">
+            <Text as="span" variant="detail" color="secondary">
+              Components ready
+            </Text>
+            <Text as="span" variant="headline" weight="semibold">
+              18 / 24
+            </Text>
+            <Progress value={75} label="Components ready" />
+            <Text as="span" variant="detail" color="muted">
+              Ready to publish to kits
+            </Text>
+          </Stack>
+        </Card>
+        <Card padding="4" radius="lg" shadow="xs" background="surfaceRaised" style={{ flex: "1 1 180px" }}>
+          <Stack gap="2">
+            <Text as="span" variant="detail" color="secondary">
+              Accessibility issues
+            </Text>
+            <Text as="span" variant="headline" weight="semibold">
+              3 open
+            </Text>
+            <Progress value={40} tone="warning" label="Accessibility issues" />
+            <Text as="span" variant="detail" color="muted">
+              Focus on overlay primitives
+            </Text>
+          </Stack>
+        </Card>
+        <Card padding="4" radius="lg" shadow="xs" background="surfaceRaised" style={{ flex: "1 1 180px" }}>
+          <Stack gap="2">
+            <Text as="span" variant="detail" color="secondary">
+              Contributors
+            </Text>
+            <Text as="span" variant="headline" weight="semibold">
+              42
+            </Text>
+            <Progress value={90} tone="accent" label="Contributor growth" />
+            <Text as="span" variant="detail" color="muted">
+              Across product teams
+            </Text>
+          </Stack>
+        </Card>
+      </Stack>
+      <Box padding="4" radius="lg" shadow="xs" background="surfaceRaised">
+        <DataTable data={WORKSTREAM_ROWS} columns={columns} caption="Component review status" />
+      </Box>
+    </Stack>
+  );
+}

--- a/docs/src/sections/Atoms.tsx
+++ b/docs/src/sections/Atoms.tsx
@@ -1,4 +1,19 @@
-import { Box, Button, Stack, Text } from "@apollo/ui";
+import {
+  Avatar,
+  Badge,
+  Box,
+  Button,
+  Card,
+  Checkbox,
+  Progress,
+  RadioGroup,
+  RadioGroupItem,
+  Skeleton,
+  Spinner,
+  Stack,
+  Switch,
+  Text,
+} from "@apollo/ui";
 
 import { Section } from "../components/Section";
 import { ShowcaseCard } from "../components/ShowcaseCard";
@@ -13,6 +28,12 @@ const SURFACE_EXAMPLES: ReadonlyArray<SurfaceExample> = [
   { token: "surface", label: "Surface", textColor: "primary" },
   { token: "surfaceRaised", label: "Raised", textColor: "primary" },
   { token: "surfaceContrast", label: "Contrast", textColor: "contrast" },
+];
+
+const TEAM_MEMBERS = [
+  { id: "aria", name: "Aria Chen", status: "online" as const },
+  { id: "diego", name: "Diego Patel", status: "busy" as const },
+  { id: "morgan", name: "Morgan Lee", status: "offline" as const },
 ];
 
 export function AtomsSection(): JSX.Element {
@@ -101,6 +122,98 @@ export function AtomsSection(): JSX.Element {
               <Button size="xs">Extra small</Button>
               <Button size="md">Medium</Button>
               <Button size="lg">Large format</Button>
+            </Stack>
+          </Stack>
+        </ShowcaseCard>
+        <ShowcaseCard
+          title="Surfaces & layout"
+          description="Combine Card and Stack primitives to organize dense interface regions with balanced spacing."
+        >
+          <Stack gap="3">
+            <Stack direction="horizontal" gap="3" wrap>
+              <Card padding="4" radius="lg" shadow="xs" background="surfaceRaised" style={{ flex: "1 1 200px" }}>
+                <Stack gap="2">
+                  <Text as="span" variant="detail" color="secondary">
+                    Guidance update
+                  </Text>
+                  <Text as="h4" variant="subtitle" weight="semibold">
+                    Publish new input patterns
+                  </Text>
+                  <Button size="sm" variant="outline" tone="neutral">
+                    View guidance
+                  </Button>
+                </Stack>
+              </Card>
+              <Card tone="accent" padding="4" radius="lg" shadow="xs" style={{ flex: "1 1 200px" }}>
+                <Stack gap="2">
+                  <Text as="span" variant="detail" weight="semibold">
+                    Token library
+                  </Text>
+                  <Text as="p" variant="body">
+                    Density-aware spacing and responsive typography travel with Stack layouts.
+                  </Text>
+                </Stack>
+              </Card>
+            </Stack>
+          </Stack>
+        </ShowcaseCard>
+        <ShowcaseCard
+          title="Selection controls"
+          description="Checkbox, radio group, and switch primitives ship accessible form semantics by default."
+        >
+          <Stack gap="3">
+            <Checkbox label="Notify team" description="Send weekly status summaries" defaultChecked />
+            <RadioGroup defaultValue="comfortable" orientation="horizontal" aria-label="Density">
+              <RadioGroupItem value="comfortable" label="Comfortable" />
+              <RadioGroupItem value="compact" label="Compact" />
+            </RadioGroup>
+            <Switch label="Enable analytics" defaultChecked />
+          </Stack>
+        </ShowcaseCard>
+        <ShowcaseCard
+          title="Avatars & skeletons"
+          description="Represent collaborators with initials-based avatars and smooth-loading skeleton placeholders."
+        >
+          <Stack gap="3">
+            <Stack direction="horizontal" gap="3" wrap align="center">
+              {TEAM_MEMBERS.map((member) => (
+                <Avatar key={member.id} name={member.name} status={member.status} size="md" />
+              ))}
+            </Stack>
+            <Card padding="4" radius="lg" shadow="xs" background="surfaceSunken">
+              <Stack gap="2">
+                <Skeleton width="70%" height="0.9rem" radius="sm" />
+                <Skeleton width="85%" height="0.75rem" radius="sm" />
+                <Skeleton width="55%" height="0.75rem" radius="sm" />
+              </Stack>
+            </Card>
+          </Stack>
+        </ShowcaseCard>
+        <ShowcaseCard
+          title="Status indicators"
+          description="Badges, progress, and spinners communicate real-time status with tone-aware palettes."
+        >
+          <Stack gap="3">
+            <Stack direction="horizontal" gap="2" wrap align="center">
+              <Badge tone="accent">New</Badge>
+              <Badge tone="success" variant="subtle">
+                Live
+              </Badge>
+              <Badge tone="warning" variant="outline">
+                Attention
+              </Badge>
+            </Stack>
+            <Stack gap="2">
+              <Text as="span" variant="detail" color="secondary">
+                Publishing tokens
+              </Text>
+              <Progress value={64} label="Publishing tokens" />
+            </Stack>
+            <Stack direction="horizontal" gap="3" align="center">
+              <Spinner size="sm" label="Loading components" />
+              <Text as="span" variant="detail" color="secondary">
+                Loading component documentation…
+              </Text>
             </Stack>
           </Stack>
         </ShowcaseCard>

--- a/docs/src/sections/Molecules.tsx
+++ b/docs/src/sections/Molecules.tsx
@@ -1,15 +1,67 @@
-import { Box, Button, Stack, Text } from "@apollo/ui";
+import { useMemo, useState } from "react";
+
+import {
+  Box,
+  Button,
+  CommandPalette,
+  CommandPaletteTrigger,
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+  DataTable,
+  DatePicker,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  Dropdown,
+  DropdownContent,
+  DropdownItem,
+  DropdownSeparator,
+  DropdownTrigger,
+  Modal,
+  ModalContent,
+  ModalDescription,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+  ModalTrigger,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+  Stack,
+  Switch,
+  Text,
+  ToastProvider,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  useApolloTheme,
+  useToast,
+  type DataTableColumn,
+} from "@apollo/ui";
 
 import { Section } from "../components/Section";
 import { ShowcaseCard } from "../components/ShowcaseCard";
 
 const FILTERS = ["Overview", "Components", "Tokens", "Accessibility"] as const;
 
+type MetricTone = "success" | "warning" | "danger";
+
 interface MetricDefinition {
   readonly label: string;
   readonly value: string;
   readonly delta: string;
-  readonly tone: "success" | "warning" | "danger";
+  readonly tone: MetricTone;
 }
 
 const METRICS: ReadonlyArray<MetricDefinition> = [
@@ -20,8 +72,231 @@ const METRICS: ReadonlyArray<MetricDefinition> = [
 
 const TAGS = ["Design tokens", "Accessibility", "Motion", "Dark mode"] as const;
 
+interface RoadmapRow {
+  readonly id: number;
+  readonly initiative: string;
+  readonly stage: "Research" | "In progress" | "Review";
+  readonly owner: string;
+}
+
+const ROADMAP_ROWS: ReadonlyArray<RoadmapRow> = [
+  { id: 1, initiative: "Color contrast audit", stage: "Review", owner: "Ana" },
+  { id: 2, initiative: "Navigation patterns", stage: "In progress", owner: "Sam" },
+  { id: 3, initiative: "Motion tokens", stage: "Research", owner: "Leah" },
+];
+
+function OverlayExamples(): JSX.Element {
+  const { theme } = useApolloTheme();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  const triggerStyle = {
+    borderRadius: theme.radii.md,
+    border: `1px solid ${theme.colors.border.subtle}`,
+    background: theme.colors.surface.surfaceRaised,
+    fontFamily: theme.typography.fonts.sans,
+    fontSize: theme.typography.variants.bodySm.fontSize,
+    lineHeight: theme.typography.variants.bodySm.lineHeight,
+    padding: `${theme.space["2"]} ${theme.space["3"]}`,
+    cursor: "pointer",
+    color: theme.colors.text.primary,
+  } as const;
+
+  return (
+    <Stack gap="3">
+      <Stack direction="horizontal" gap="2" wrap>
+        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+          <DialogTrigger>
+            <Button size="sm">Dialog</Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Share release notes</DialogTitle>
+              <DialogDescription>Summarize new component additions for product teams.</DialogDescription>
+            </DialogHeader>
+            <Text as="p" variant="body">
+              Dialog primitives provide accessible focus management, keyboard support, and escape-to-close behaviour out of the box.
+            </Text>
+            <DialogFooter>
+              <Button variant="ghost" tone="neutral" onClick={() => setDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button size="sm" onClick={() => setDialogOpen(false)}>
+                Publish
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+        <Modal open={modalOpen} onOpenChange={setModalOpen}>
+          <ModalTrigger>
+            <Button size="sm" variant="outline" tone="neutral">
+              Modal
+            </Button>
+          </ModalTrigger>
+          <ModalContent>
+            <ModalHeader>
+              <ModalTitle>Archive component</ModalTitle>
+              <ModalDescription>Remove legacy variants while keeping tokens untouched.</ModalDescription>
+            </ModalHeader>
+            <Text as="p" variant="body">
+              Modals reuse dialog primitives with opinionated sizing to emphasize confirmations and destructive flows.
+            </Text>
+            <ModalFooter>
+              <Button variant="ghost" tone="neutral" onClick={() => setModalOpen(false)}>
+                Dismiss
+              </Button>
+              <Button size="sm" tone="danger" onClick={() => setModalOpen(false)}>
+                Archive
+              </Button>
+            </ModalFooter>
+          </ModalContent>
+        </Modal>
+        <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+          <SheetTrigger>
+            <Button size="sm" variant="subtle" tone="neutral">
+              Sheet
+            </Button>
+          </SheetTrigger>
+          <SheetContent>
+            <SheetHeader>
+              <SheetTitle>Notification settings</SheetTitle>
+              <SheetDescription>Toggle digest delivery for upcoming releases and audits.</SheetDescription>
+            </SheetHeader>
+            <Stack gap="2">
+              <Switch label="Release emails" defaultChecked />
+              <Switch label="Weekly digest" />
+            </Stack>
+            <SheetFooter>
+              <Button variant="ghost" tone="neutral" onClick={() => setSheetOpen(false)}>
+                Cancel
+              </Button>
+              <Button size="sm" onClick={() => setSheetOpen(false)}>
+                Save preferences
+              </Button>
+            </SheetFooter>
+          </SheetContent>
+        </Sheet>
+      </Stack>
+      <Stack direction="horizontal" gap="2" wrap align="center">
+        <Dropdown>
+          <DropdownTrigger style={triggerStyle}>Dropdown</DropdownTrigger>
+          <DropdownContent>
+            <DropdownItem>Profile</DropdownItem>
+            <DropdownItem>Billing</DropdownItem>
+            <DropdownSeparator />
+            <DropdownItem danger>Delete</DropdownItem>
+          </DropdownContent>
+        </Dropdown>
+        <Tooltip>
+          <TooltipTrigger>
+            <Button size="sm" variant="ghost" tone="neutral">
+              Tooltip
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Accessible helper text for icon-only controls.</TooltipContent>
+        </Tooltip>
+        <ContextMenu>
+          <ContextMenuTrigger>
+            <Button size="sm" variant="ghost" tone="neutral">
+              Context menu
+            </Button>
+          </ContextMenuTrigger>
+          <ContextMenuContent>
+            <ContextMenuItem>Duplicate</ContextMenuItem>
+            <ContextMenuSeparator />
+            <ContextMenuItem>Archive</ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
+      </Stack>
+    </Stack>
+  );
+}
+
+function ToastTriggerButton(): JSX.Element {
+  const { publish } = useToast();
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      tone="neutral"
+      onClick={() => publish({ title: "Saved", description: "Design tokens synced across apps." })}
+    >
+      Trigger toast
+    </Button>
+  );
+}
+
+function CommandPaletteShowcase(): JSX.Element {
+  const [lastCommand, setLastCommand] = useState<string | null>(null);
+
+  const commands = useMemo(
+    () => [
+      {
+        id: "new-component",
+        title: "Create component",
+        description: "Generate a new primitive or molecule",
+        shortcut: ["N"],
+        onSelect: () => setLastCommand("Create component"),
+        group: "Components",
+      },
+      {
+        id: "open-docs",
+        title: "Open documentation",
+        description: "Jump to the component guidelines",
+        shortcut: ["D"],
+        onSelect: () => setLastCommand("Open documentation"),
+        group: "Navigation",
+      },
+      {
+        id: "theme",
+        title: "Toggle appearance",
+        description: "Switch between light and dark modes",
+        shortcut: ["T"],
+        onSelect: () => setLastCommand("Toggle appearance"),
+        group: "Preferences",
+      },
+    ],
+    [],
+  );
+
+  return (
+    <Stack gap="2">
+      <CommandPalette commands={commands} hotkey="k">
+        <CommandPaletteTrigger>
+          Open command palette
+        </CommandPaletteTrigger>
+      </CommandPalette>
+      <Text as="span" variant="detail" color="secondary">
+        Last command: {lastCommand ?? "Select an action or press ⌘K"}
+      </Text>
+    </Stack>
+  );
+}
+
 export function MoleculesSection(): JSX.Element {
   const activeFilter = FILTERS[1];
+
+  const roadmapColumns = useMemo<ReadonlyArray<DataTableColumn<RoadmapRow>>>(
+    () => [
+      {
+        id: "initiative",
+        header: "Initiative",
+        accessor: (row) => row.initiative,
+      },
+      {
+        id: "stage",
+        header: "Stage",
+        accessor: (row) => row.stage,
+      },
+      {
+        id: "owner",
+        header: "Owner",
+        accessor: (row) => row.owner,
+      },
+    ],
+    [],
+  );
 
   return (
     <Section
@@ -106,6 +381,34 @@ export function MoleculesSection(): JSX.Element {
               </Box>
             ))}
           </Stack>
+        </ShowcaseCard>
+        <ShowcaseCard
+          title="Data inputs"
+          description="Pair structured pickers with sortable tables to summarize roadmap progress."
+        >
+          <Stack gap="3">
+            <DatePicker placeholder="Filter by quarter" />
+            <Box padding="3" radius="lg" background="surfaceSunken">
+              <DataTable data={ROADMAP_ROWS} columns={roadmapColumns} caption="Roadmap initiatives" />
+            </Box>
+          </Stack>
+        </ShowcaseCard>
+        <ShowcaseCard
+          title="Overlay interactions"
+          description="Dialogs, modals, sheets, dropdowns, tooltips, and context menus share consistent behaviours."
+        >
+          <OverlayExamples />
+        </ShowcaseCard>
+        <ShowcaseCard
+          title="Command palette & toasts"
+          description="Global command menus and toast notifications coordinate feedback and shortcuts."
+        >
+          <ToastProvider>
+            <Stack gap="3">
+              <ToastTriggerButton />
+              <CommandPaletteShowcase />
+            </Stack>
+          </ToastProvider>
         </ShowcaseCard>
       </Stack>
     </Section>

--- a/docs/src/sections/Organisms.tsx
+++ b/docs/src/sections/Organisms.tsx
@@ -2,6 +2,8 @@ import { Box, Button, Stack, Text } from "@apollo/ui";
 
 import { Section } from "../components/Section";
 import { ShowcaseCard } from "../components/ShowcaseCard";
+import { AppShellDemo } from "../components/demos/AppShellDemo";
+import { DashboardDemo } from "../components/demos/DashboardDemo";
 
 const UPDATE_HIGHLIGHTS = [
   "Expanded accent palette for accessibility",
@@ -19,12 +21,6 @@ const CHECKLIST: ReadonlyArray<ChecklistItem> = [
   { label: "Adopt new button variants", complete: false },
   { label: "Audit custom surfaces", complete: false },
 ];
-
-const TEAM_METRICS = [
-  { label: "In-flight projects", value: "5", helper: "Design system adoption" },
-  { label: "Design reviews", value: "18", helper: "Last 7 days" },
-  { label: "Contributors", value: "42", helper: "Across product teams" },
-] as const;
 
 export function OrganismsSection(): JSX.Element {
   return (
@@ -80,46 +76,16 @@ export function OrganismsSection(): JSX.Element {
           </Stack>
         </ShowcaseCard>
         <ShowcaseCard
-          title="Team health dashboard"
-          description="Organize molecules into responsive panels that summarize ongoing design system efforts."
+          title="Application shell"
+          description="Sidebar navigation, top-level actions, and content panels compose into a cohesive workspace chrome."
         >
-          <Stack gap="4">
-            <Stack direction="horizontal" gap="3" wrap>
-              {TEAM_METRICS.map((metric) => (
-                <Box
-                  key={metric.label}
-                  padding="4"
-                  radius="lg"
-                  shadow="xs"
-                  background="surface"
-                  border="subtle"
-                  style={{ flex: "1 1 180px" }}
-                >
-                  <Stack gap="1">
-                    <Text variant="subtitle" weight="semibold">
-                      {metric.value}
-                    </Text>
-                    <Text variant="detail" color="secondary">
-                      {metric.label}
-                    </Text>
-                    <Text variant="detail" color="muted">
-                      {metric.helper}
-                    </Text>
-                  </Stack>
-                </Box>
-              ))}
-            </Stack>
-            <Box padding="4" radius="lg" background="surfaceSunken" border="none">
-              <Stack gap="2">
-                <Text variant="detail" color="secondary">
-                  Next milestone
-                </Text>
-                <Text variant="body">
-                  Publish accessibility audit for the marketing site and integrate the new high-contrast palette tokens.
-                </Text>
-              </Stack>
-            </Box>
-          </Stack>
+          <AppShellDemo />
+        </ShowcaseCard>
+        <ShowcaseCard
+          title="Design ops dashboard"
+          description="Combine data tables, metrics, and pickers to track adoption and accessibility outcomes."
+        >
+          <DashboardDemo />
         </ShowcaseCard>
         <ShowcaseCard
           title="Onboarding checklist"


### PR DESCRIPTION
## Summary
- expand the atoms section to cover form controls, avatars, status indicators, and layout cards
- add molecule demos for data pickers, tables, overlays, the command palette, and toast notifications
- introduce organism examples for an application shell and design-ops dashboard used across the docs

## Testing
- bun run typecheck
- bun test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68d12be9c7c4832ea4befe91b1ae3384