### PR TITLE
Refine documentation layout and visuals

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -15,6 +15,18 @@ import { AtomsSection } from "./sections/Atoms";
 import { MoleculesSection } from "./sections/Molecules";
 import { OrganismsSection } from "./sections/Organisms";
 
+const withAlpha = (hex: string, alpha: number): string => {
+  const normalized = hex.replace("#", "");
+  if (normalized.length !== 6) {
+    return hex;
+  }
+  const red = parseInt(normalized.slice(0, 2), 16);
+  const green = parseInt(normalized.slice(2, 4), 16);
+  const blue = parseInt(normalized.slice(4, 6), 16);
+  const clamped = Math.min(1, Math.max(0, alpha));
+  return `rgba(${red}, ${green}, ${blue}, ${clamped})`;
+};
+
 const GlobalStyles = createGlobalStyle`
   :root {
     color-scheme: ${({ theme }) => theme.appearance};
@@ -26,8 +38,16 @@ const GlobalStyles = createGlobalStyle`
     margin: 0;
     font-family: ${({ theme }) => theme.typography.fonts.sans};
     background-color: ${({ theme }) => theme.colors.surface.background};
+    background-image: ${({ theme }) =>
+      [
+        `radial-gradient(140% 120% at 0% 0%, ${withAlpha(theme.colors.action.accent.subtle, 0.55)} 0%, transparent 70%)`,
+        `radial-gradient(120% 120% at 100% 0%, ${withAlpha(theme.colors.action.accent.solid, 0.32)} 0%, transparent 65%)`,
+      ].join(", ")};
+    background-repeat: no-repeat;
+    background-attachment: fixed;
     color: ${({ theme }) => theme.colors.text.primary};
     min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
   }
   a {
     color: inherit;
@@ -40,6 +60,18 @@ const NAVIGATION_LINKS = [
   { id: "organisms", label: "Organisms" },
 ] as const;
 
+const Navigation = styled.nav`
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: ${({ theme }) => theme.space["2"]};
+  padding: ${({ theme }) => `${theme.space["2"]} ${theme.space["2"]}`};
+  border-radius: ${({ theme }) => theme.radii.lg};
+  border: 1px solid ${({ theme }) => theme.colors.border.subtle};
+  background-color: ${({ theme }) => theme.colors.surface.surfaceRaised};
+  box-shadow: ${({ theme }) => theme.shadows.xs};
+`;
+
 const NavigationLink = styled.a`
   text-decoration: none;
   display: inline-flex;
@@ -47,18 +79,24 @@ const NavigationLink = styled.a`
   justify-content: center;
   padding: ${({ theme }) => `${theme.space["2"]} ${theme.space["3"]}`};
   border-radius: ${({ theme }) => theme.radii.md};
-  background-color: ${({ theme }) => theme.colors.surface.surfaceSunken};
-  color: ${({ theme }) => theme.colors.action.accent.solid};
+  color: ${({ theme }) => theme.colors.text.secondary};
   font-size: ${({ theme }) => theme.typography.variants.detail.fontSize};
   line-height: ${({ theme }) => theme.typography.variants.detail.lineHeight};
   letter-spacing: ${({ theme }) => theme.typography.variants.detail.letterSpacing};
   font-weight: ${({ theme }) => theme.typography.weights.semibold};
+  border: 1px solid transparent;
   transition: ${({ theme }) =>
     theme.motion.reduced
       ? "none"
-      : `background-color ${theme.motion.duration.fast} ${theme.motion.easing.standard}`};
+      : [
+          `background-color ${theme.motion.duration.fast} ${theme.motion.easing.standard}`,
+          `color ${theme.motion.duration.fast} ${theme.motion.easing.standard}`,
+          `border-color ${theme.motion.duration.fast} ${theme.motion.easing.standard}`,
+        ].join(", ")};
   &:hover {
-    background-color: ${({ theme }) => theme.colors.surface.surfaceRaised};
+    color: ${({ theme }) => theme.colors.text.accent};
+    border-color: ${({ theme }) => theme.colors.border.subtle};
+    background-color: ${({ theme }) => theme.colors.surface.surfaceSunken};
   }
   &:focus-visible {
     outline: none;
@@ -163,7 +201,15 @@ function PreferencesPanel(): JSX.Element {
   };
 
   return (
-    <Card as="section" aria-labelledby="theme-controls-heading" padding="6">
+    <Card
+      as="section"
+      aria-labelledby="theme-controls-heading"
+      padding="6"
+      radius="xl"
+      shadow="sm"
+      border="subtle"
+      background="surfaceRaised"
+    >
       <Stack gap="4">
         <Stack gap="1">
           <Text as="h2" id="theme-controls-heading" variant="subtitle" weight="semibold">
@@ -213,13 +259,13 @@ export function App(): JSX.Element {
                 Explore the foundational atoms, composite molecules, and opinionated organisms built with Apollo UI primitives.
               </Text>
             </Stack>
-            <Stack direction="horizontal" gap="3" wrap as="nav" aria-label="Section navigation">
+            <Navigation aria-label="Section navigation">
               {NAVIGATION_LINKS.map((link) => (
                 <NavigationLink key={link.id} href={`#${link.id}`}>
                   {link.label}
                 </NavigationLink>
               ))}
-            </Stack>
+            </Navigation>
             <PreferencesPanel />
           </Stack>
           <AtomsSection />

--- a/docs/src/components/ShowcaseCard.tsx
+++ b/docs/src/components/ShowcaseCard.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode } from "react";
 
 import { Card, Stack, Text } from "@apollo/ui";
+import styled from "styled-components";
 
 export interface ShowcaseCardProps {
   readonly title: string;
@@ -9,6 +10,44 @@ export interface ShowcaseCardProps {
   readonly tone?: "neutral" | "accent";
 }
 
+const StyledShowcaseCard = styled(Card)`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.space["5"]};
+  padding: ${({ theme }) => theme.space["6"]};
+  border-radius: ${({ theme }) => theme.radii.xl};
+  border-color: ${({ theme }) => theme.colors.border.subtle};
+  box-shadow: ${({ theme }) => theme.shadows.sm};
+  background-color: ${({ theme }) => theme.colors.surface.surfaceRaised};
+  transition: ${({ theme }) =>
+    theme.motion.reduced
+      ? "none"
+      : `transform ${theme.motion.duration.fast} ${theme.motion.easing.emphasized}`};
+
+  @media (prefers-reduced-motion: no-preference) {
+    &:hover {
+      transform: translateY(-2px);
+    }
+  }
+
+  &[data-tone="accent"] {
+    color: ${({ theme }) => theme.colors.action.accent.subtleForeground};
+    border-color: ${({ theme }) => theme.colors.action.accent.outline};
+    background-color: ${({ theme }) => theme.colors.action.accent.subtle};
+    background-image: ${({ theme }) => `radial-gradient(
+        120% 140% at 0% 0%,
+        color-mix(in srgb, ${theme.colors.action.accent.subtle} 60%, transparent) 0%,
+        transparent 70%
+      ),
+      radial-gradient(
+        120% 120% at 100% 0%,
+        color-mix(in srgb, ${theme.colors.action.accent.solid} 28%, transparent) 0%,
+        transparent 65%
+      )`};
+  }
+`;
+
 export function ShowcaseCard({
   title,
   description,
@@ -16,16 +55,15 @@ export function ShowcaseCard({
   tone = "neutral",
 }: ShowcaseCardProps): JSX.Element {
   return (
-    <Card
+    <StyledShowcaseCard
       as="article"
       tone={tone}
-      padding="6"
       radius="xl"
       shadow="sm"
       border={tone === "accent" ? "strong" : "subtle"}
-      style={{ flex: "1 1 300px" }}
+      background={tone === "accent" ? undefined : "surfaceRaised"}
     >
-      <Stack gap="4">
+      <Stack gap="4" style={{ flex: "1 1 auto" }}>
         <Stack gap="1">
           <Text as="h3" variant="subtitle" weight="semibold">
             {title}
@@ -36,6 +74,6 @@ export function ShowcaseCard({
         </Stack>
         {children}
       </Stack>
-    </Card>
+    </StyledShowcaseCard>
   );
 }

--- a/docs/src/components/ShowcaseGrid.tsx
+++ b/docs/src/components/ShowcaseGrid.tsx
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+
+export const ShowcaseGrid = styled.div`
+  display: grid;
+  width: 100%;
+  gap: ${({ theme }) => theme.space["6"]};
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: stretch;
+
+  @media (min-width: 1024px) {
+    gap: ${({ theme }) => theme.space["8"]};
+  }
+
+  @media (min-width: 1280px) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+`;

--- a/docs/src/sections/Atoms.tsx
+++ b/docs/src/sections/Atoms.tsx
@@ -17,6 +17,7 @@ import {
 
 import { Section } from "../components/Section";
 import { ShowcaseCard } from "../components/ShowcaseCard";
+import { ShowcaseGrid } from "../components/ShowcaseGrid";
 
 interface SurfaceExample {
   readonly token: "surface" | "surfaceRaised" | "surfaceContrast";
@@ -43,7 +44,7 @@ export function AtomsSection(): JSX.Element {
       title="Atoms"
       description="Foundational primitives that wrap low-level HTML semantics with Apollo's design tokens."
     >
-      <Stack direction="horizontal" gap="6" wrap>
+      <ShowcaseGrid>
         <ShowcaseCard
           title="Box"
           description="Layout primitive exposing consistent spacing, radius, borders, and surface colors."
@@ -217,7 +218,7 @@ export function AtomsSection(): JSX.Element {
             </Stack>
           </Stack>
         </ShowcaseCard>
-      </Stack>
+      </ShowcaseGrid>
     </Section>
   );
 }

--- a/docs/src/sections/Molecules.tsx
+++ b/docs/src/sections/Molecules.tsx
@@ -52,6 +52,7 @@ import {
 
 import { Section } from "../components/Section";
 import { ShowcaseCard } from "../components/ShowcaseCard";
+import { ShowcaseGrid } from "../components/ShowcaseGrid";
 
 const FILTERS = ["Overview", "Components", "Tokens", "Accessibility"] as const;
 
@@ -304,7 +305,7 @@ export function MoleculesSection(): JSX.Element {
       title="Molecules"
       description="Composable assemblies of atoms that capture reusable interface patterns."
     >
-      <Stack direction="horizontal" gap="6" wrap>
+      <ShowcaseGrid>
         <ShowcaseCard
           title="Filter toolbar"
           description="Buttons compose into toggle groups with clear selection and keyboard focus handling."
@@ -410,7 +411,7 @@ export function MoleculesSection(): JSX.Element {
             </Stack>
           </ToastProvider>
         </ShowcaseCard>
-      </Stack>
+      </ShowcaseGrid>
     </Section>
   );
 }

--- a/docs/src/sections/Organisms.tsx
+++ b/docs/src/sections/Organisms.tsx
@@ -2,6 +2,7 @@ import { Box, Button, Stack, Text } from "@apollo/ui";
 
 import { Section } from "../components/Section";
 import { ShowcaseCard } from "../components/ShowcaseCard";
+import { ShowcaseGrid } from "../components/ShowcaseGrid";
 import { AppShellDemo } from "../components/demos/AppShellDemo";
 import { DashboardDemo } from "../components/demos/DashboardDemo";
 
@@ -29,7 +30,7 @@ export function OrganismsSection(): JSX.Element {
       title="Organisms"
       description="High-order compositions that orchestrate atoms and molecules into product-ready experiences."
     >
-      <Stack direction="horizontal" gap="6" wrap>
+      <ShowcaseGrid>
         <ShowcaseCard
           tone="accent"
           title="Product update panel"
@@ -134,7 +135,7 @@ export function OrganismsSection(): JSX.Element {
             </Stack>
           </Stack>
         </ShowcaseCard>
-      </Stack>
+      </ShowcaseGrid>
     </Section>
   );
 }


### PR DESCRIPTION
## Summary
- refresh the documentation shell with ambient background gradients and refined navigation styling
- introduce a reusable `ShowcaseGrid` and restyle showcase cards for consistent elevation and accent gradients
- convert atom, molecule, and organism sections to the new grid and polish the theme controls panel

## Testing
- bun test
- bun run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d131c62d7c832ea105b24275ffceca